### PR TITLE
fix: windows installer and venv path

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,14 @@ You can also run the installation command manually.
 
 - `nginx.enable`: Enable coc-nginx extension, default: `true`
 - `nginx.commandPath`: The custom path to the nginx-language-server (Absolute path), default: `""`
+- `nginx.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
 
 ## Commands
 
 - `nginx.installLanguageServer`: Install nginx-language-server (builtin)
   - It will be installed in this path:
     - Mac/Linux: `~/.config/coc/extensions/coc-nginx-data/nginx-language-server/venv/bin/nginx-language-server`
-    - Windows: `~/AppData/Local/coc/extensions/coc-nginx-data/nginx-language-server/venv/bin/nginx-language-server`
+    - Windows: `~/AppData/Local/coc/extensions/coc-nginx-data/nginx-language-server/venv/Scripts/nginx-language-server.exe`
 
 ## Known issue I have identified
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,12 @@
         "nginx.commandPath": {
           "type": "string",
           "default": "",
-          "description": "(Optional) The custom path to the nginx-language-server (Absolute path)."
+          "description": "The custom path to the nginx-language-server (Absolute path)."
+        },
+        "nginx.builtin.pythonPath": {
+          "type": "string",
+          "default": "",
+          "description": "Python 3.x path (Absolute path) to be used for built-in install"
         }
       }
     },

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -13,9 +13,9 @@ const exec = util.promisify(child_process.exec);
 export async function nginxLsInstall(pythonCommand: string, context: ExtensionContext): Promise<void> {
   const pathVenv = path.join(context.storagePath, 'nginx-language-server', 'venv');
 
-  let pathVenvPython = path.join(context.storagePath, 'pysen-ls', 'venv', 'bin', 'python');
+  let pathVenvPython = path.join(context.storagePath, 'nginx-language-server', 'venv', 'bin', 'python');
   if (process.platform === 'win32') {
-    pathVenvPython = path.join(context.storagePath, 'pysen-ls', 'venv', 'Scripts', 'python');
+    pathVenvPython = path.join(context.storagePath, 'nginx-language-server', 'venv', 'Scripts', 'python');
   }
 
   const statusItem = window.createStatusBarItem(0, { progress: true });

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -10,23 +10,28 @@ import { NGINX_LS_VERSION } from './constant';
 
 const exec = util.promisify(child_process.exec);
 
-export async function nginxLsInstall(context: ExtensionContext): Promise<void> {
+export async function nginxLsInstall(pythonCommand: string, context: ExtensionContext): Promise<void> {
   const pathVenv = path.join(context.storagePath, 'nginx-language-server', 'venv');
-  const pathPip = path.join(pathVenv, 'bin', 'pip');
+
+  let pathVenvPython = path.join(context.storagePath, 'pysen-ls', 'venv', 'bin', 'python');
+  if (process.platform === 'win32') {
+    pathVenvPython = path.join(context.storagePath, 'pysen-ls', 'venv', 'Scripts', 'python');
+  }
 
   const statusItem = window.createStatusBarItem(0, { progress: true });
-  statusItem.text = `Install nginx-language-server ...`;
+  statusItem.text = `Install nginx-language-server...`;
   statusItem.show();
 
   const installCmd =
-    `python3 -m venv ${pathVenv} && ` + `${pathPip} install -U pip nginx-language-server==${NGINX_LS_VERSION}`;
+    `${pathVenvPython} -m venv ${pathVenv} && ` +
+    `${pathVenvPython} -m pip install -U pip nginx-language-server==${NGINX_LS_VERSION}`;
 
   rimraf.sync(pathVenv);
   try {
-    window.showWarningMessage(`Install nginx-language-server...`);
+    window.showMessage(`Install nginx-language-server...`);
     await exec(installCmd);
     statusItem.hide();
-    window.showWarningMessage(`nginx-language-server: installed!`);
+    window.showMessage(`nginx-language-server: installed!`);
   } catch (error) {
     statusItem.hide();
     window.showErrorMessage(`nginx-language-server: install failed. | ${error}`);

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -23,7 +23,7 @@ export async function nginxLsInstall(pythonCommand: string, context: ExtensionCo
   statusItem.show();
 
   const installCmd =
-    `${pathVenvPython} -m venv ${pathVenv} && ` +
+    `${pythonCommand} -m venv ${pathVenv} && ` +
     `${pathVenvPython} -m pip install -U pip nginx-language-server==${NGINX_LS_VERSION}`;
 
   rimraf.sync(pathVenv);


### PR DESCRIPTION
- Fix path of venv on windows (Change to Scripts instead of bin.)
- Change the installation procedure to `python -m pip` instead of using pip in venv directly.
- Added python3 and python command detection (since python3 commands may not be present on Windows and other special environments).