### PR TITLE
feat: Add formatter feature using "nginxfmt"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 - Completion
 - Hover
+- Format by [nginxfmt](https://pypi.org/project/nginxfmt/)
 
 ## Install
 
@@ -48,6 +49,8 @@ You can also run the installation command manually.
 - `nginx.enable`: Enable coc-nginx extension, default: `true`
 - `nginx.commandPath`: The custom path to the nginx-language-server (Absolute path), default: `""`
 - `nginx.builtin.pythonPath`: Python 3.x path (Absolute path) to be used for built-in install, default: `""`
+- `nginx.nginxfmt.commandPath`: The custom path to the nginxfmt (Absolute path), default: `""`
+- `nginx.nginxfmt.indent`: Specify number of spaces for indentation, default: `4`
 
 ## Commands
 
@@ -55,6 +58,7 @@ You can also run the installation command manually.
   - It will be installed in this path:
     - Mac/Linux: `~/.config/coc/extensions/coc-nginx-data/nginx-language-server/venv/bin/nginx-language-server`
     - Windows: `~/AppData/Local/coc/extensions/coc-nginx-data/nginx-language-server/venv/Scripts/nginx-language-server.exe`
+- `nginx.format`: Run nginxfmt
 
 ## Known issue I have identified
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@yaegassy/coc-nginx",
   "version": "0.1.1",
   "nginxLsVersion": "0.5.1",
+  "nginxFmtVersion": "1.2.2",
   "description": "nginx-language-server extension for coc.nvim",
   "author": "yaegassy <yosstools@gmail.com>",
   "license": "MIT",
@@ -35,6 +36,7 @@
     "@types/node": "^12.11.7",
     "@types/rimraf": "^3.0.0",
     "@types/which": "^2.0.0",
+    "@types/tmp": "^0.2.0",
     "@typescript-eslint/eslint-plugin": "^4.8.2",
     "@typescript-eslint/parser": "^4.8.2",
     "coc.nvim": "^0.0.80",
@@ -45,7 +47,8 @@
     "prettier": "^2.2.0",
     "rimraf": "^3.0.2",
     "typescript": "^4.1.2",
-    "which": "^2.0.2"
+    "which": "^2.0.2",
+    "tmp": "^0.1.0"
   },
   "activationEvents": [
     "onLanguage:nginx",
@@ -70,6 +73,16 @@
           "type": "string",
           "default": "",
           "description": "Python 3.x path (Absolute path) to be used for built-in install"
+        },
+        "nginx.nginxfmt.commandPath": {
+          "type": "string",
+          "default": "",
+          "description": "The custom path to the nginxfmt (Absolute path)."
+        },
+        "nginx.nginxfmt.indent": {
+          "type": "number",
+          "default": 4,
+          "description": "Specify number of spaces for indentation"
         }
       }
     },
@@ -77,6 +90,10 @@
       {
         "command": "nginx.installLanguageServer",
         "title": "Install nginx-language-server (builtin)"
+      },
+      {
+        "command": "nginx.format",
+        "title": "Run nginxfmt"
       }
     ]
   }

--- a/src/constant.ts
+++ b/src/constant.ts
@@ -5,6 +5,7 @@
  */
 
 // @ts-ignore
-import { nginxLsVersion } from '../package.json';
+import { nginxLsVersion, nginxFmtVersion } from '../package.json';
 
 export const NGINX_LS_VERSION = nginxLsVersion;
+export const NGINX_FMT_VERSION = nginxFmtVersion;

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,112 @@
+import {
+  DocumentFormattingEditProvider,
+  Range,
+  TextDocument,
+  TextEdit,
+  Uri,
+  window,
+  workspace,
+  ExtensionContext,
+  OutputChannel,
+} from 'coc.nvim';
+
+import cp from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import tmp from 'tmp';
+
+export async function doFormat(
+  context: ExtensionContext,
+  outputChannel: OutputChannel,
+  document: TextDocument,
+  range?: Range
+): Promise<string> {
+  if (document.languageId !== 'nginx') {
+    throw '"nginxfmt" cannot run, not a nginx file';
+  }
+
+  const extensionConfig = workspace.getConfiguration('nginx');
+  const nginxfmtIndent = extensionConfig.get<number>('nginxfmt.indent', 4);
+
+  let toolPath = extensionConfig.get('nginxfmt.commandPath', '');
+  if (!toolPath) {
+    if (
+      fs.existsSync(path.join(context.storagePath, 'nginx-language-server', 'venv', 'Scripts', 'nginxfmt.exe')) ||
+      fs.existsSync(path.join(context.storagePath, 'nginx-language-server', 'venv', 'bin', 'nginxfmt'))
+    ) {
+      if (process.platform === 'win32') {
+        toolPath = path.join(context.storagePath, 'nginx-language-server', 'venv', 'Scripts', 'nginxfmt.exe');
+      } else {
+        toolPath = path.join(context.storagePath, 'nginx-language-server', 'venv', 'bin', 'nginxfmt');
+      }
+    } else {
+      throw 'Unable to find the nginxfmt command.';
+    }
+  }
+
+  const fileName = Uri.parse(document.uri).fsPath;
+  const text = document.getText(range);
+
+  const args: string[] = [];
+  const opts = { cwd: path.dirname(fileName) };
+
+  if (nginxfmtIndent) {
+    args.push('--indent', nginxfmtIndent.toString());
+  }
+
+  const tmpFile = tmp.fileSync();
+  fs.writeFileSync(tmpFile.name, text);
+
+  // ---- Output the command to be executed to channel log. ----
+  outputChannel.appendLine(`${'#'.repeat(10)} nginxfmt\n`);
+  outputChannel.appendLine(`Cwd: ${opts.cwd}`);
+  outputChannel.appendLine(`Run: ${toolPath} ${args.join(' ')} ${tmpFile.name}`);
+  outputChannel.appendLine(`Args: ${args.join(' ')}`);
+
+  return new Promise(function (resolve) {
+    cp.execFile(toolPath, [...args, tmpFile.name], opts, function (err) {
+      if (err) {
+        tmpFile.removeCallback();
+        outputChannel.appendLine(`\n==== Error ====\n${err.message}`);
+        window.showErrorMessage('There was an error while running nginxfmt.');
+        throw err;
+      }
+
+      const text = fs.readFileSync(tmpFile.name, 'utf-8');
+      tmpFile.removeCallback();
+
+      resolve(text);
+    });
+  });
+}
+
+export function fullDocumentRange(document: TextDocument): Range {
+  const lastLineId = document.lineCount - 1;
+  const doc = workspace.getDocument(document.uri);
+
+  return Range.create({ character: 0, line: 0 }, { character: doc.getline(lastLineId).length, line: lastLineId });
+}
+
+class NginxFormattingEditProvider implements DocumentFormattingEditProvider {
+  public _context: ExtensionContext;
+  public _outputChannel: OutputChannel;
+
+  constructor(context: ExtensionContext, outputChannel: OutputChannel) {
+    this._context = context;
+    this._outputChannel = outputChannel;
+  }
+
+  public provideDocumentFormattingEdits(document: TextDocument): Promise<TextEdit[]> {
+    return this._provideEdits(document, undefined);
+  }
+
+  private async _provideEdits(document: TextDocument, range?: Range): Promise<TextEdit[]> {
+    const code = await doFormat(this._context, this._outputChannel, document, range);
+    if (!range) {
+      range = fullDocumentRange(document);
+    }
+    return [TextEdit.replace(range, code)];
+  }
+}
+
+export default NginxFormattingEditProvider;

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -6,7 +6,7 @@ import rimraf from 'rimraf';
 import child_process from 'child_process';
 import util from 'util';
 
-import { NGINX_LS_VERSION } from './constant';
+import { NGINX_LS_VERSION, NGINX_FMT_VERSION } from './constant';
 
 const exec = util.promisify(child_process.exec);
 
@@ -19,16 +19,16 @@ export async function nginxLsInstall(pythonCommand: string, context: ExtensionCo
   }
 
   const statusItem = window.createStatusBarItem(0, { progress: true });
-  statusItem.text = `Install nginx-language-server...`;
+  statusItem.text = `Install nginx-language-server and more tools...`;
   statusItem.show();
 
   const installCmd =
     `${pythonCommand} -m venv ${pathVenv} && ` +
-    `${pathVenvPython} -m pip install -U pip nginx-language-server==${NGINX_LS_VERSION}`;
+    `${pathVenvPython} -m pip install -U pip nginx-language-server==${NGINX_LS_VERSION} nginxfmt==${NGINX_FMT_VERSION}`;
 
   rimraf.sync(pathVenv);
   try {
-    window.showMessage(`Install nginx-language-server...`);
+    window.showMessage(`Install nginx-language-server and more tools...`);
     await exec(installCmd);
     statusItem.hide();
     window.showMessage(`nginx-language-server: installed!`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -95,6 +95,11 @@
     "@types/glob" "*"
     "@types/node" "*"
 
+"@types/tmp@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
+  integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
+
 "@types/which@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/which/-/which-2.0.0.tgz#446d35586611dee657120de8e0457382a658fc25"
@@ -926,6 +931,13 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -1032,6 +1044,13 @@ text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+tmp@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.1.0.tgz#ee434a4e22543082e294ba6201dcc6eafefa2877"
+  integrity sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==
+  dependencies:
+    rimraf "^2.6.3"
 
 to-regex-range@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
## Description

Close https://github.com/yaegassy/coc-nginx/issues/4

- nginxfmt
  - PyPI
    - <https://pypi.org/project/nginxfmt/>
  - GitHub
    - <https://github.com/slomkowski/nginx-config-formatter>

## DEMO

![coc-nginx-nginxfmt-demo](https://user-images.githubusercontent.com/188642/117621209-53010880-b1ac-11eb-9d94-8abf07c04d6d.gif)

## Usage

- `:call CocAction('format')`
- `:CocCommand nginx.format`

## Install

Changed so that `nginxfmt` is also installed when the `:CocCommand nginx.installLanguageServer` install command is executed.

If you are using the old "coc-nginx", please run `:CocCommand nginx.installLanguageServer` again.

## Add configuration

- `nginx.nginxfmt.commandPath`
- `nginx.nginxfmt.indent`

## Add Command

- `nginx.format`

## Misc

When the formatter feature is added to `nginx-language-server` itself, this feature will be removed.

