### PR TITLE
fix: Add stop and start for client when reinstalling language server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
   context.subscriptions.push(
     commands.registerCommand('nginx.installLanguageServer', async () => {
       if (pythonCommand) {
+        if (client.serviceState !== 5) {
+          await client.stop();
+        }
         await installWrapper(pythonCommand, context);
+        client.start();
       } else {
         window.showErrorMessage('python3/python command not found');
       }


### PR DESCRIPTION
There was a problem that reinstallation could not be completed properly depending on the environment (e.g. "Windows").